### PR TITLE
Fix how buy menu is hidden

### DIFF
--- a/frontend/src/components/GameDisplay.jsx
+++ b/frontend/src/components/GameDisplay.jsx
@@ -137,7 +137,7 @@ export default function GameDisplay({game, assets}) {
         </Text>}
 
         <GameInfo level={game.level} phase={game.phase} height={height} depth={depth} gold={game.gold} />
-        {game.phase === BUILD && <BuyMenu game={game}/> }
+        <BuyMenu game={game}/>
 
         <PerspectiveCamera makeDefault fov={50} position={ [20, 15, 20] }/>
         <OrbitControls target={new THREE.Vector3(width/2-.5, 0, depth/2-.5)}/>

--- a/frontend/src/components/ui/BuyMenu.jsx
+++ b/frontend/src/components/ui/BuyMenu.jsx
@@ -5,6 +5,7 @@ import { Text } from "@react-three/drei"
 import { Tile, TileType } from '/src/map/Tile.js';
 import { tileKey } from '/src/map/GameMap.js';
 import BuildGhostView from "../views/BuildGhostView";
+import { BUILD } from "../../Game";
 
 import ArrowTower from "../../entities/towers/ArrowTower";
 import RockTower from "../../entities/towers/RockTower";
@@ -214,8 +215,8 @@ export default function BuyMenu({game}) {
         )
     });
 
-    return (
-        <>
+    const showBuyMenu = (game.phase === BUILD) && !game.over;
+    return showBuyMenu && <>
             <Text
                 position={[width/2, 0,  depth + 2]}
                 rotation={[-Math.PI/2, 0, 0]}
@@ -226,5 +227,4 @@ export default function BuyMenu({game}) {
             {buyTerraformButtons}
             {newTower && <BuildGhostView structure={newTower} />}
         </>
-    )
 }


### PR DESCRIPTION
The buy menu was previously hidden externally, which prevented the click handler from being disabled correctly during game phase changes. This PR updates the `BuyMenu` component to handle visibility internally.

Closes #58 