### PR TITLE
Prevent status tower buff

### DIFF
--- a/frontend/src/Game.js
+++ b/frontend/src/Game.js
@@ -97,7 +97,7 @@ export default class Game {
     }
 
     getAllTowers = () => {
-        return Array.from(this.gameMap.towers.values().filter(t => !!t));
+        return Array.from(this.gameMap.towers.values());
     }
 
     getTower = (x, y) => this.gameMap.getTower(x, y)
@@ -314,12 +314,13 @@ export default class Game {
 
     applyBuffs = () => {
         for (const tower of this.getAllTowers()) {
-            tower.buffs.clear();
+            tower.clearBuffs();
         }
         for (const buffTower of this.getAllTowers().filter(t => t?.name === 'buffTower')) {
-            for (const otherTower of this.getAllTowers().filter(t => t.name !== 'buffTower')) {
+            for (const otherTower of this.getAllTowers()) {
+                if (!otherTower.canBuff(BUFFED)) continue;
                 if ((buffTower.getProjectilePath(otherTower.position, this.gameMap))) {
-                    otherTower.buffs.add(BUFFED);
+                    otherTower.applyBuff(BUFFED);
                 }
             }
         }

--- a/frontend/src/components/ui/ItemInfo.jsx
+++ b/frontend/src/components/ui/ItemInfo.jsx
@@ -42,13 +42,13 @@ const TerraformInfo = ({ name }) => {
 }
 
 const TowerInfo = ({ tower }) => {
-    const { name, price, damage, cooldown, minRange, maxRange, buffs, description } = tower
+    const { name, price, damage, cooldown, minRange, maxRange, description } = tower
     return <div>
         <h5>Selected Tower</h5>
         <ul>
             <li>Type: {name}</li>
             <li>Price: {price}</li>
-            <li>Damage: {buffs.has(BUFFED) ? damage * 2 : damage}</li>
+            <li>Damage: {tower.hasBuff(BUFFED) ? damage * 2 : damage}</li>
             <li>Cooldown: {cooldown}</li>
             {minRange
                 ? <li>Range: {minRange} - {maxRange}</li>

--- a/frontend/src/components/views/StructureView.jsx
+++ b/frontend/src/components/views/StructureView.jsx
@@ -5,8 +5,11 @@ import { useLoader } from "@react-three/fiber";
 import HpView from "./HpView";
 import { StatusView } from "./StatusView";
 
+const NO_BUFFS = new Set();
+
 const StructureRender = (assets, structure) => {
-    const { scale, name, hp, maxHp, offset, rotation, buffs, height } = structure;
+    const { scale, name, hp, maxHp, offset, rotation, height } = structure;
+    const buffs = structure.getBuffs() || NO_BUFFS;
     const coordinates = convertToRenderCoordinates(structure, offset);
 
     const modelFile = modelFiles[name] || modelFiles.placeholder;

--- a/frontend/src/entities/Castle.js
+++ b/frontend/src/entities/Castle.js
@@ -15,11 +15,27 @@ export default class Castle extends Entity {
         this.height = 0;
         this.status = Status.PERMANENT;
         this.description = "This is your castle. Prevent the enemies from reaching it!"
-        this.buffs = new Set();
     }
 
     takeDamage = (damage) => {
         this.hp -= damage;
         this.hp = Math.max(0, round(this.hp));
+    }
+
+    // Provide buff interface expected for towers
+    applyBuff(_buff) { }
+
+    removeBuff(_buff) { }
+
+    hasBuff(_buff) { }
+
+    getBuffs() {
+        return null;
+    }
+
+    clearBuffs() { }
+
+    canBuff(_buff) {
+        return false;
     }
 }

--- a/frontend/src/entities/Portal.js
+++ b/frontend/src/entities/Portal.js
@@ -11,7 +11,23 @@ export default class Portal extends Entity {
         this.height = 0;
         this.status = Status.PERMANENT;
         this.description = "This is the portal from which enemies will spawn."
-        this.buffs = new Set();
+    }
+
+    // Provide buff interface expected for towers
+    applyBuff(_buff) { }
+
+    removeBuff(_buff) { }
+
+    hasBuff(_buff) { }
+
+    getBuffs() {
+        return null;
+    }
+
+    clearBuffs() { }
+
+    canBuff(_buff) {
+        return false;
     }
 }
 

--- a/frontend/src/entities/towers/BuffTower.js
+++ b/frontend/src/entities/towers/BuffTower.js
@@ -20,4 +20,8 @@ export default class BuffTower extends Tower {
     getProjectilePath = (target, _gameMap, _travelTime) => {
         return getAdjacentTilePath(this, target);
     }
+
+    canBuff(_buff) {
+        return false;
+    }
 }

--- a/frontend/src/entities/towers/FireTower.js
+++ b/frontend/src/entities/towers/FireTower.js
@@ -41,4 +41,8 @@ export default class FireTower extends Tower {
         this.rotateTowardsTarget(path.at(-1));
         return new Flame(...this.position, path, target, enemies);
     }
+
+    canBuff(_buff) {
+        return false;
+    }
 }

--- a/frontend/src/entities/towers/IceTower.js
+++ b/frontend/src/entities/towers/IceTower.js
@@ -40,4 +40,8 @@ export default class IceTower extends Tower {
         this.rotateTowardsTarget(path.at(-1));
         return new Snowball(...this.position, path, target, enemies);
     }
+
+    canBuff(_buff) {
+        return false;
+    }
 }

--- a/frontend/src/entities/towers/SlowTower.js
+++ b/frontend/src/entities/towers/SlowTower.js
@@ -43,4 +43,8 @@ export default class SlowTower extends Tower {
         dummyProjectile.hp = 0;
         return dummyProjectile;
     }
+
+    canBuff(_buff) {
+        return false;
+    }
 }

--- a/frontend/src/entities/towers/Tower.js
+++ b/frontend/src/entities/towers/Tower.js
@@ -15,7 +15,7 @@ export default class Tower extends Entity {
         super(x, y, z, new THREE.Quaternion(), scale);
         this.hp = Infinity;
         this.status = status;
-        this.buffs = new Set();
+        this._buffs = new Set();
         this.height = 0;
     }
 
@@ -26,5 +26,29 @@ export default class Tower extends Entity {
 
     getTopOfTowerPosition() {
         return [this.x, this.y, this.z + this.height];
+    }
+
+    applyBuff(buff) {
+        this._buffs.add(buff);
+    }
+
+    removeBuff(buff) {
+        this._buffs.delete(buff);
+    }
+
+    hasBuff(buff) {
+        return this._buffs.has(buff);
+    }
+
+    getBuffs() {
+        return this._buffs;
+    }
+
+    clearBuffs() {
+        this._buffs.clear();
+    }
+
+    canBuff(_buff) {
+        return true;
     }
 }


### PR DESCRIPTION
This PR creates a `canBuff()` method, which is used to prevent status towers from getting buffed.

Not the biggest fan of the tower duality of the castle & portal but I left it alone for now.

Closes #127 